### PR TITLE
terraform fmt and fix s3 warningd

### DIFF
--- a/ManagementTf/iam.tf
+++ b/ManagementTf/iam.tf
@@ -5,7 +5,7 @@ variable "linked_account_id" {
 
 variable "function_prefix" {
   description = "only needed if you used in main deployment"
-  default = ""
+  default     = ""
 }
 
 resource "aws_iam_role" "role" {

--- a/crawler.tf
+++ b/crawler.tf
@@ -1,5 +1,5 @@
 resource "aws_glue_crawler" "organization" {
-  database_name = "${var.cur_database}"
+  database_name = var.cur_database
   name          = "${var.function_prefix}Org_Glue_Crawler"
   role          = aws_iam_role.AWS-Organization-Data-Glue-Crawler.arn
   schedule      = "cron(0 8 ? * MON *)"
@@ -75,5 +75,5 @@ data "aws_iam_policy" "GluePolicy" {
 
 resource "aws_iam_role_policy_attachment" "glue-role-policy-attach" {
   role       = aws_iam_role.AWS-Organization-Data-Glue-Crawler.id
-  policy_arn = "${data.aws_iam_policy.GluePolicy.arn}"
+  policy_arn = data.aws_iam_policy.GluePolicy.arn
 }

--- a/main.tf
+++ b/main.tf
@@ -48,14 +48,20 @@ data "aws_caller_identity" "current" {
 
 resource "aws_s3_bucket" "destination_bucket" {
   bucket = var.destination_bucket
-  versioning {
-    enabled = true
+}
+
+resource "aws_s3_bucket_versioning" "destination_bucket" {
+  bucket = aws_s3_bucket.destination_bucket.id
+  versioning_configuration {
+    status = "Enabled"
   }
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm     = "AES256"
-      }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "destination_bucket" {
+  bucket = aws_s3_bucket.destination_bucket.bucket
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,8 +13,8 @@ variable "destination_bucket" {
 }
 
 variable "account" {
-  type = string
-  default = "Linked"
+  type        = string
+  default     = "Linked"
   description = "if linked not needed if Management account put in Management"
 }
 


### PR DESCRIPTION
```
Warning: Argument is deprecated
│ 
│   with module.aws_tf_organisation_data.aws_s3_bucket.destination_bucket,
│   on .terraform/modules/aws_tf_organisation_data/main.tf line 49, in resource "aws_s3_bucket" "destination_bucket":
│   49: resource "aws_s3_bucket" "destination_bucket" {
│ 
│ Use the aws_s3_bucket_server_side_encryption_configuration resource instead
│ 
│ (and one more similar warning elsewhere)
╵
```